### PR TITLE
Utilisation d'une grille de largeur 2 au lieu d'une seule.

### DIFF
--- a/source/SignalProcessing/CMakeLists.txt
+++ b/source/SignalProcessing/CMakeLists.txt
@@ -21,17 +21,20 @@ if (CUDA_FOUND)
         include/*)
 
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-std=c++14;-DUSE_CUDA;--expt-relaxed-constexpr;-Xptxas;-O3")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-gencode=arch=compute_62,code=sm_62;-rdc=true")
+    set(CUDA_SEPARABLE_COMPILATION ON)
+
 
     cuda_add_library(SignalProcessing
         STATIC
         ${source_files})
-
     target_link_libraries(SignalProcessing
         armadillo
         ${openblas_LIBRARY}
         ${fftw_LIBRARY}
         gfortran
-        ${CUDA_LIBRARIES})
+        ${CUDA_LIBRARIES}
+        ${CUDA_cudadevrt_LIBRARY})
 
     add_definitions(-DUSE_CUDA)
 

--- a/source/SignalProcessing/include/SignalProcessing/Cuda/Conversion/ArrayToPcmConversion.h
+++ b/source/SignalProcessing/include/SignalProcessing/Cuda/Conversion/ArrayToPcmConversion.h
@@ -53,8 +53,8 @@ namespace adaptone
     __device__ void arrayToSignedPcm(const T* input, uint8_t* outputBytes, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         PcmT* output = reinterpret_cast<PcmT*>(outputBytes);
@@ -78,8 +78,8 @@ namespace adaptone
     {
         constexpr T AbsMin = 1 << 23;
 
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         for (std::size_t i = startIndex; i < n; i += stride)
@@ -107,8 +107,8 @@ namespace adaptone
     {
         constexpr T AbsMin = 1 << 23;
 
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         int32_t* output = reinterpret_cast<int32_t*>(outputBytes);
@@ -128,8 +128,8 @@ namespace adaptone
     __device__ void arrayToUnsignedPcm(const T* input, uint8_t* outputBytes, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         PcmT* output = reinterpret_cast<PcmT*>(outputBytes);
@@ -154,8 +154,8 @@ namespace adaptone
     {
         constexpr T Max = (1 << 24) - 1;
 
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         for (std::size_t i = startIndex; i < n; i += stride)
@@ -183,8 +183,8 @@ namespace adaptone
     {
         constexpr T Max = (1 << 24) - 1;
 
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         uint32_t* output = reinterpret_cast<uint32_t*>(outputBytes);
@@ -204,8 +204,8 @@ namespace adaptone
     __device__ void arrayToFloatingPointPcm(const T* input, uint8_t* outputBytes, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         PcmT* output = reinterpret_cast<PcmT*>(outputBytes);

--- a/source/SignalProcessing/include/SignalProcessing/Cuda/Conversion/PcmToArrayConversion.h
+++ b/source/SignalProcessing/include/SignalProcessing/Cuda/Conversion/PcmToArrayConversion.h
@@ -13,8 +13,8 @@ namespace adaptone
     __device__ void signedPcmToArray(const uint8_t* inputBytes, T* output, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         const PcmT* input = reinterpret_cast<const PcmT*>(inputBytes);
@@ -33,8 +33,8 @@ namespace adaptone
     __device__ void signed24PcmToArray(const uint8_t* inputBytes, T* output, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         constexpr T AbsMin = 1 << 23;
@@ -60,8 +60,8 @@ namespace adaptone
     {
         constexpr T AbsMin = 1 << 23;
 
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         const int32_t* input = reinterpret_cast<const int32_t*>(inputBytes);
@@ -80,8 +80,8 @@ namespace adaptone
     __device__ void unsignedPcmToArray(const uint8_t* inputBytes, T* output, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         const PcmT* input = reinterpret_cast<const PcmT*>(inputBytes);
@@ -102,8 +102,8 @@ namespace adaptone
     {
         constexpr T Max = (1 << 24) - 1;
 
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         for (std::size_t i = startIndex; i < n; i += stride)
@@ -127,8 +127,8 @@ namespace adaptone
     {
         constexpr T Max = (1 << 24) - 1;
 
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         const uint32_t* input = reinterpret_cast<const uint32_t*>(inputBytes);
@@ -147,8 +147,8 @@ namespace adaptone
     __device__ void floatingPointPcmToArray(const uint8_t* inputBytes, T* output, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         const PcmT* input = reinterpret_cast<const PcmT*>(inputBytes);

--- a/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/DelayProcessing.h
+++ b/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/DelayProcessing.h
@@ -15,8 +15,8 @@ namespace adaptone
         std::size_t currentDelayedOutputFrameIndex,
         std::size_t delayedOutputFrameCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         for (std::size_t i = startIndex; i < n; i += stride)

--- a/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/GainProcessing.h
+++ b/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/GainProcessing.h
@@ -10,8 +10,8 @@ namespace adaptone
     __device__ void processGain(T* inputFrame, T* outputFrame, T* gains, std::size_t frameSampleCount,
         std::size_t channelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * channelCount;
 
         for (std::size_t i = startIndex; i < n; i += stride)

--- a/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/MixProcessing.h
+++ b/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/MixProcessing.h
@@ -10,8 +10,8 @@ namespace adaptone
     __device__ void processMix(T* inputFrame, T* outputFrame, T* gains, std::size_t frameSampleCount,
         std::size_t inputChannelCount, std::size_t outputChannelCount)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = frameSampleCount * outputChannelCount;
 
         for (std::size_t outputIndex = startIndex; outputIndex < n; outputIndex += stride)

--- a/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/SoundLevelProcessing.h
+++ b/source/SignalProcessing/include/SignalProcessing/Cuda/Processing/SoundLevelProcessing.h
@@ -14,8 +14,8 @@ namespace adaptone
     template<class T>
     __device__ void processSoundLevel(CudaSoundLevelBuffers<T>& soundLevelBuffer, T* currentInputFrame)
     {
-        std::size_t startIndex = threadIdx.x;
-        std::size_t stride = blockDim.x;
+        std::size_t startIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        std::size_t stride = blockDim.x * gridDim.x;
         std::size_t n = soundLevelBuffer.channelCount();
 
         for (std::size_t channelIndex = startIndex; channelIndex < n; channelIndex += stride)

--- a/source/SignalProcessing/test/CMakeLists.txt
+++ b/source/SignalProcessing/test/CMakeLists.txt
@@ -35,7 +35,8 @@ if (CUDA_FOUND)
         gfortran
         gtest
         gmock
-        ${CUDA_LIBRARIES})
+        ${CUDA_LIBRARIES}
+        ${CUDA_cudadevrt_LIBRARY})
 
     add_definitions(-DUSE_CUDA)
 


### PR DESCRIPTION
Malheurement, le gain en performance n'est pas aussi grand que je souhaitais.

```
FrameSampleCount = 32
    Avant : 
        Elapsed time (avg) = 0.000429753 s
        Elapsed time (min) = 0.000377404 s
        Elapsed time (max) = 0.000981751 s

    Après :
        Elapsed time (avg) = 0.000398905 s
        Elapsed time (min) = 0.000327965 s
        Elapsed time (max) = 0.000876121 s

FrameSampleCount = 256 (celui qu'on utilise avec la carte de son)
    Avant : 
        Elapsed time (avg) = 0.00165588 s
        Elapsed time (min) = 0.00158703 s
        Elapsed time (max) = 0.00238513 s

    Après : 
        Elapsed time (avg) = 0.00140144 s
        Elapsed time (min) = 0.00130197 s
        Elapsed time (max) = 0.00219064 s

FrameSampleCount = 1024
    Avant :
        Elapsed time (avg) = 0.00611134 s
        Elapsed time (min) = 0.00594514 s
        Elapsed time (max) = 0.00729124 s

    Après : 
        Elapsed time (avg) = 0.00461367 s
        Elapsed time (min) = 0.00440064 s
        Elapsed time (max) = 0.00585547 s

```